### PR TITLE
move the run and other active code buttons to the bottom

### DIFF
--- a/runestone/activecode/js/activecode.js
+++ b/runestone/activecode/js/activecode.js
@@ -223,7 +223,7 @@ ActiveCode.prototype.createControls = function () {
     // lc mod
     // the control button go inside the container for the code
     // rather than outside above it
-    $(this.codeDiv).prepend(ctrlDiv);
+    $(this.codeDiv).append(ctrlDiv);
 
 };
 


### PR DESCRIPTION
Students commented that it is difficult to click run, then quickly
scroll down past the code to the output to see it. Sometimes this is
an issue because input() triggers an alerts, which block scrolling.
Other times, it is an issue because turtles begin moving and we don't
get to see the very beginning of the motion.